### PR TITLE
Fix making textures in VRAM

### DIFF
--- a/libsf2d/source/sf2d_texture.c
+++ b/libsf2d/source/sf2d_texture.c
@@ -78,7 +78,13 @@ sf2d_texture *sf2d_create_texture(int width, int height, sf2d_texfmt pixel_forma
 	texture->data_size = data_size;
 	texture->data = data;
 
-	memset(texture->data, 0, texture->data_size);
+	if (place == SF2D_PLACE_VRAM) {
+		GX_SetMemoryFill(NULL, texture->data, 0x00000000, (u32*)&((u8*)texture->data)[texture->data_size], GX_FILL_TRIGGER | GX_FILL_32BIT_DEPTH,
+			NULL, 0x00000000, NULL, 0);
+		gspWaitForPSC0();
+	} else {
+		memset(texture->data, 0, texture->data_size);
+	}
 
 	return texture;
 }


### PR DESCRIPTION
Initializing a VRAM texture should not be done with CPU access.
