### PR TITLE
Add function to blend texture with UV coordinates and color

### DIFF
--- a/libsf2d/include/sf2d.h
+++ b/libsf2d/include/sf2d.h
@@ -665,8 +665,7 @@ void sf2d_draw_texture_depth(const sf2d_texture *texture, int x, int y, signed s
 void sf2d_draw_texture_depth_blend(const sf2d_texture *texture, int x, int y, signed short z, u32 color);
 
 /**
- * @brief Draws a texture using custom texture coordinates and parameters
- * @param texture the texture to draw
+ * @brief Draws the currently-bound texture using custom texture coordinates
  * @param left the left coordinate of the texture to start drawing
  * @param top the top coordinate of the texture to start drawing
  * @param width the width to draw from the starting left coordinate
@@ -675,10 +674,25 @@ void sf2d_draw_texture_depth_blend(const sf2d_texture *texture, int x, int y, si
  * @param v0 the V texture coordinate of the top vertices
  * @param u1 the U texture coordinate of the right vertices
  * @param v1 the V texture coordinate of the bottom vertices
- * @param params the parameters to draw the texture with
  */
+void sf2d_draw_quad_uv_current(float left, float top, float right, float bottom, float u0, float v0,
+	float u1, float v1);
+
+/**
+ * @brief Like sf2d_draw_quad_uv_current, but binds the texture with the given params
+ * @param texture the texture to draw
+ * @param params the parameters to draw the texture with
+ **/
 void sf2d_draw_quad_uv(const sf2d_texture *texture, float left, float top, float right, float bottom,
 	float u0, float v0, float u1, float v1, unsigned int params);
+
+/**
+ * @brief Like sf2d_draw_quad_uv_current, but binds the texture with the given blend color
+ * @param texture the texture to draw
+ * @param color the color to blend the texture with
+ **/
+void sf2d_draw_quad_uv_blend(const sf2d_texture *texture, float left, float top, float right, float bottom,
+	float u0, float v0, float u1, float v1, u32 color);
 
 /**
  * @brief Changes a pixel of the texture

--- a/libsf2d/source/sf2d_texture.c
+++ b/libsf2d/source/sf2d_texture.c
@@ -727,8 +727,7 @@ void sf2d_draw_texture_depth_blend(const sf2d_texture *texture, int x, int y, si
 	sf2d_draw_texture_depth_generic(texture, x, y, z);
 }
 
-
-void sf2d_draw_quad_uv(const sf2d_texture *texture, float left, float top, float right, float bottom, float u0, float v0, float u1, float v1, unsigned int params)
+void sf2d_draw_quad_uv_current(float left, float top, float right, float bottom, float u0, float v0, float u1, float v1)
 {
 	sf2d_vertex_pos_tex *vertices = sf2d_pool_memalign(4 * sizeof(sf2d_vertex_pos_tex), 8);
 	if (!vertices) return;
@@ -743,8 +742,6 @@ void sf2d_draw_quad_uv(const sf2d_texture *texture, float left, float top, float
 	vertices[2].texcoord = (sf2d_vector_2f){u0, v1};
 	vertices[3].texcoord = (sf2d_vector_2f){u1, v1};
 
-	sf2d_bind_texture_parameters(texture, GPU_TEXUNIT0, params);
-
 	GPU_SetAttributeBuffers(
 		2, // number of attributes
 		(u32*)osConvertVirtToPhys(vertices),
@@ -758,6 +755,18 @@ void sf2d_draw_quad_uv(const sf2d_texture *texture, float left, float top, float
 	);
 
 	GPU_DrawArray(GPU_TRIANGLE_STRIP, 0, 4);
+}
+
+void sf2d_draw_quad_uv(const sf2d_texture *texture, float left, float top, float right, float bottom, float u0, float v0, float u1, float v1, unsigned int params)
+{
+	sf2d_bind_texture_parameters(texture, GPU_TEXUNIT0, params);
+	sf2d_draw_quad_uv_current(left, top, right, bottom, u0, v0, u1, v1);
+}
+
+void sf2d_draw_quad_uv_blend(const sf2d_texture *texture, float left, float top, float right, float bottom, float u0, float v0, float u1, float v1, u32 color)
+{
+	sf2d_bind_texture_color(texture, GPU_TEXUNIT0, color);
+	sf2d_draw_quad_uv_current(left, top, right, bottom, u0, v0, u1, v1);
 }
 
 // Grabbed from Citra Emulator (citra/src/video_core/utils.h)


### PR DESCRIPTION
Needed `sf2d_draw_quad_uv()` with `sf2d_bind_texture_color()`, but that wasn't available.

Also happy if at least `sf2d_draw_quad_uv_current()` would be merged, as I can always call `sf2d_bind_texture_color()` and `sf2d_draw_quad_uv_current()` manually myself, `sf2d_draw_quad_uv_blend()` is just there for convenience and `sf2d_draw_quad_uv()` for backwards compatibility.
